### PR TITLE
Add network admin volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ EXPOSE 1521
 EXPOSE 8080
 EXPOSE 5500
 
-VOLUME ["/u01/app/oracle"]
+VOLUME ["/u01/app/oracle", "/u01/app/oracle-product/12.1.0.2/dbhome_1/network/admin"]
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ Oracle should be run in “privileged” mode as oracle requires special ports a
 However in real environment it's better to use more comprehensive statement useful for real life:
 ```sh
 $ docker run -d --name oracle \
-  --privileged -v $(pwd)/oradata:/u01/app/oracle \
-  -p 8080:8080 -p 1521:1521 absolutapps/oracle-12c-ee 
+  --privileged \
+  -v $(pwd)/oradata:/u01/app/oracle \
+  -v $(pwd)/networkadmin:/u01/app/oracle-product/12.1.0.2/dbhome_1/network/admin \
+  -p 8080:8080 -p 1521:1521 absolutapps/oracle-12c-ee
 ```
-In this case database settings and data will be saved to $(pwd)/oradata folder and ports will be exposed either to localhost or boot2docker container (MacOs and Win). 
+In this case database settings and data will be saved to $(pwd)/oradata folder and ports will be exposed either to localhost or boot2docker container (MacOs and Win).
+Network configuration files under $(pwd)/networkadmin will be mounted into the container so that listener and other network settings can be customized.
 
 ### Additional options
  - `ORACLE_SID` - Oracle SID (default to ORCL)


### PR DESCRIPTION
## Summary
- add a volume for `$ORACLE_HOME/network/admin`
- document the new volume in the example run command

## Testing
- `shellcheck --version` *(fails: command not found)*
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850aaf65fd8832c9081869bf80774ec