### PR TITLE
Add configurable env paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM absolutapps/oracle-12c-ee-base
 ENV INIT_MEM_PST 40
 ENV SW_ONLY false
 ENV TERM dumb
+ENV TNS_ADMIN ${ORACLE_HOME}/network/admin
+ENV FORMS60_PATH /path/to/forms
+ENV REPORTS60_PATH /path/to/reports
 
 ADD entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,20 @@ $ docker run -d --name oracle \
   -p 8080:8080 -p 1521:1521 absolutapps/oracle-12c-ee 
 ```
 In this case database settings and data will be saved to $(pwd)/oradata folder and ports will be exposed either to localhost or boot2docker container (MacOs and Win). 
+Environment variables can be overridden at runtime using `-e VARIABLE=value` when invoking `docker run`.
+
 
 ### Additional options
- - `ORACLE_SID` - Oracle SID (default to ORCL)
- - `SERVICE_NAME`	- $ORACLE_SID
- - Listener port - 1521	 
- - EM port - 8080	 
- - SYS, SYSTEM passwords: oracle	 
- - Amount of memory	40%	`INIT_MEM_PST`
+ - `ORACLE_SID` - Oracle SID (default `ORCL`)
+ - `SERVICE_NAME` - service name used for connections (defaults to `ORACLE_SID`)
+ - `INIT_MEM_PST` - percentage of system memory dedicated to the database (default `40`)
+ - `SW_ONLY` - when `true`, install binaries only without creating a database
+ - `TNS_ADMIN` - path to network configuration files (default `$ORACLE_HOME/network/admin`)
+ - `FORMS60_PATH` - search path for Oracle Forms modules
+ - `REPORTS60_PATH` - search path for Oracle Reports modules
+ - Listener port - `1521`
+ - EM port - `8080`
+ - SYS, SYSTEM passwords: `oracle`
 
 ### Running scripts at startup
 Shell scripts (sh) and sql scripts (sql) placed in `/oracle.init.d/`directory will be executed after database creation (or start). 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# ensure defaults for optional paths
+export TNS_ADMIN=${TNS_ADMIN:-$ORACLE_HOME/network/admin}
+export FORMS60_PATH=${FORMS60_PATH:-/path/to/forms}
+export REPORTS60_PATH=${REPORTS60_PATH:-/path/to/reports}
+
 sysctl -p > /dev/null 2>&1 || true
 
 chown -R oracle:oinstall $ORACLE_BASE 
@@ -11,9 +16,23 @@ ln -s /u01/app/oracle-product $ORACLE_BASE/product
 /u01/app/oraInventory/orainstRoot.sh > /dev/null 2>&1
 echo | $ORACLE_BASE/product/12.1.0.2/dbhome_1/root.sh  > /dev/null 2>&1 || true
 
+generate_tnsnames(){
+ gosu oracle cat > "$TNS_ADMIN/tnsnames.ora" <<EOF
+${SERVICE_NAME:-$ORACLE_SID} =
+  (DESCRIPTION =
+    (ADDRESS = (PROTOCOL = TCP)(HOST = $(hostname))(PORT = 1521))
+    (CONNECT_DATA =
+      (SERVER = DEDICATED)
+      (SERVICE_NAME = ${SERVICE_NAME:-$ORACLE_SID})
+    )
+  )
+EOF
+}
+
 start_listener(){
- gosu oracle echo "LISTENER = (DESCRIPTION_LIST = (DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = $(hostname))(PORT = 1521))))" > $ORACLE_HOME/network/admin/listener.ora
- gosu oracle echo "" > $ORACLE_HOME/network/admin/sqlnet.ora
+ gosu oracle echo "LISTENER = (DESCRIPTION_LIST = (DESCRIPTION = (ADDRESS = (PROTOCOL = TCP)(HOST = $(hostname))(PORT = 1521))))" > "$TNS_ADMIN/listener.ora"
+ gosu oracle echo "" > "$TNS_ADMIN/sqlnet.ora"
+ generate_tnsnames
  gosu oracle lsnrctl start
 }
 


### PR DESCRIPTION
## Summary
- expose more environment variables in `Dockerfile`
- generate `tnsnames.ora` and use configurable network admin path
- document all available environment variables

## Testing
- `bash -n entrypoint.sh`

------
https://chatgpt.com/codex/tasks/task_e_6850aaf7e074832ca01befedccaa7247